### PR TITLE
Help content

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,11 @@ Assumptions
 Changelog
 =========
 
+1.0.2
+-----
+
+* `help_context` parameter of `EmailRegistry.register()` may now contain tuple of description and example value shown in preview
+
 1.0.1
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@ Changelog
 -----
 
 * `help_context` parameter of `EmailRegistry.register()` may now contain tuple of description and example value shown in preview
+* Changed EmailTemplateAdminForm title to use ChoiceField choices as lazy function. This way all registered templates are printed in admin form, independent of order Python loads application modules.
 
 1.0.1
 -----

--- a/emailtemplates/forms.py
+++ b/emailtemplates/forms.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 from django.template import Template
 from django.template import TemplateSyntaxError
 from django.utils.safestring import mark_safe
+from django.utils.functional import lazy
 
 from emailtemplates.models import EmailTemplate
 from emailtemplates.registry import email_templates
@@ -14,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class EmailTemplateAdminForm(forms.ModelForm):
-    title = forms.ChoiceField(choices=email_templates.email_template_choices())
+    title = forms.ChoiceField(choices=lazy(email_templates.email_template_choices, list))
 
     class Meta:
         model = EmailTemplate

--- a/emailtemplates/registry.py
+++ b/emailtemplates/registry.py
@@ -32,6 +32,8 @@ class HelpContext(object):
         for k, v in self.help_context.items():
             if isinstance(v, tuple) and len(v) == 2:
                 help_values[k] = v[1]
+            else:
+                help_values[k] = u"<%s>" % k
         return help_values
 
 
@@ -51,11 +53,11 @@ class RegistrationItem(object):
 
     def context_description(self):
         help_text_item = lambda k, v: u"%s - %s" % (self._context_key(k), v) if v else u"%s" % self._context_key(k)
-        return u"<br/>".join([help_text_item(k, v) for (k, v) in sorted(self.help_context.items())])
+        return u"<br/>".join([help_text_item(k, v) for (k, v) in sorted(self.help_context_obj.get_help_keys().items())])
 
     def as_form_help_text(self):
         item_help_text = _(u"<b>USAGE: %s</b>") % self.help_text if self.help_text else u""
-        item_help_context = _(u"<b>CONTEXT:</b><br/>%s") % self.context_description() if self.help_context else u""
+        item_help_context = _(u"<b>CONTEXT:</b><br/>%s") % self.context_description() if self.help_context_obj.get_help_keys() else u""
         return u"<br/>".join((item_help_text, item_help_context))
 
     def as_form_choice(self):

--- a/emailtemplates/registry.py
+++ b/emailtemplates/registry.py
@@ -21,7 +21,7 @@ class HelpContext(object):
     def get_help_keys(self):
         help_keys = {}
         for k, v in self.help_context.items():
-            if isinstance(v, tuple) and len(v) == 2:
+            if isinstance(v, tuple):
                 help_keys[k] = v[0]
             else:
                 help_keys[k] = v

--- a/emailtemplates/registry.py
+++ b/emailtemplates/registry.py
@@ -14,12 +14,37 @@ class NotRegistered(Exception):
     pass
 
 
+class HelpContext(object):
+    def __init__(self, help_context):
+        self.help_context = help_context or {}
+
+    def get_help_keys(self):
+        help_keys = {}
+        for k, v in self.help_context.items():
+            if isinstance(v, tuple) and len(v) == 2:
+                help_keys[k] = v[0]
+            else:
+                help_keys[k] = v
+        return help_keys
+
+    def get_help_values(self):
+        help_values = {}
+        for k, v in self.help_context.items():
+            if isinstance(v, tuple) and len(v) == 2:
+                help_values[k] = v[1]
+        return help_values
+
+
 class RegistrationItem(object):
 
-    def __init__(self, path, help_text=None, help_context=None):
+    def __init__(self, path, help_text=u"", help_context=None):
         self.path = path
-        self.help_text = help_text or u""
-        self.help_context = help_context or {}
+        self.help_text = help_text
+        self.help_context_obj = HelpContext(help_context)
+
+    @property
+    def help_context(self):
+        return self.help_context_obj.get_help_keys()
 
     def _context_key(self, key):
         return u"<b>{{ %s }}</b>" % key
@@ -35,6 +60,9 @@ class RegistrationItem(object):
 
     def as_form_choice(self):
         return self.path, self.path
+
+    def get_help_content(self):
+        return self.help_context_obj.get_help_values()
 
 
 class EmailTemplateRegistry(object):
@@ -79,6 +107,9 @@ class EmailTemplateRegistry(object):
 
     def get_help_context(self, path):
         return self.get_registration(path).help_context
+
+    def get_help_content(self, path):
+        return self.get_registration(path).get_help_content()
 
     def registration_items(self):
         return self._registry.values()

--- a/emailtemplates/registry.py
+++ b/emailtemplates/registry.py
@@ -15,10 +15,16 @@ class NotRegistered(Exception):
 
 
 class HelpContext(object):
+    """
+    Provides helpers methods for displaying help context keys (descriptions) and values (examples).
+    """
     def __init__(self, help_context):
         self.help_context = help_context or {}
 
     def get_help_keys(self):
+        """
+        Returns dict of help_context keys (description texts used in `EmailRegistry.register()` method).
+        """
         help_keys = {}
         for k, v in self.help_context.items():
             if isinstance(v, tuple):
@@ -28,6 +34,9 @@ class HelpContext(object):
         return help_keys
 
     def get_help_values(self):
+        """
+        Returns dict of help_context values (example values submitted in `EmailRegistry.register()` method).
+        """
         help_values = {}
         for k, v in self.help_context.items():
             if isinstance(v, tuple) and len(v) == 2:
@@ -83,6 +92,9 @@ class EmailTemplateRegistry(object):
         :param path: Template file path. It will become immutable registry lookup key.
         :param help_text: Help text to describe template in admin site
         :param help_context: Dictionary of possible keys used in the context and description of their content
+
+        `help_context` items values may be strings or tuples of two strings. If strings, then email template preview
+        will use variable names to fill context, otherwise the second tuple element will become example value.
 
         If an email template is already registered, this will raise AlreadyRegistered.
         """

--- a/emailtemplates/tests/test_template_registry.py
+++ b/emailtemplates/tests/test_template_registry.py
@@ -1,7 +1,34 @@
 # coding=utf-8
 from django.test import TestCase
 
-from ..registry import EmailTemplateRegistry, RegistrationItem
+from ..registry import EmailTemplateRegistry, RegistrationItem, HelpContext
+
+
+class HelpContextTest(TestCase):
+
+    def test_get_help_keys(self):
+        help_context = HelpContext({
+            'username': (u'Name of user in hello expression', u'superman_90'),
+            'full_name': (u'Full user name', u'John Smith'),
+            'property': u'Some other property',
+        })
+        self.assertDictEqual(help_context.get_help_keys(), {
+            'username': u'Name of user in hello expression',
+            'full_name': u'Full user name',
+            'property': u'Some other property',
+        })
+
+    def test_get_help_values(self):
+        help_context = HelpContext({
+            'username': (u'Name of user in hello expression', u'superman_90'),
+            'full_name': (u'Full user name', u'John Smith'),
+            'property': u'Some other property',
+        })
+        self.assertDictEqual(help_context.get_help_values(), {
+            'username': u'superman_90',
+            'full_name': u'John Smith',
+            'property': u'<property>',
+        })
 
 
 class RegistrationItemTest(TestCase):
@@ -57,11 +84,13 @@ class EmailTemplateRegistryTest(TestCase):
                                    help_context={
                                        'username': (u'Name of user in hello expression', u'superman_90'),
                                        'full_name': (u'Full user name', u'John Smith'),
+                                       'property': u'Some other property',
                                    })
         help_content = template_registry.get_help_content('hello_template.html')
         self.assertDictEqual(help_content, {
             'username': u'superman_90',
             'full_name': u'John Smith',
+            'property': u'<property>',
         })
 
     def test_get_email_templates(self):

--- a/emailtemplates/tests/test_template_registry.py
+++ b/emailtemplates/tests/test_template_registry.py
@@ -9,7 +9,7 @@ class RegistrationItemTest(TestCase):
     def test_context_description(self):
         item = RegistrationItem('hello_template.html', help_text=u'Hello template',
                                 help_context={'username': u'Name of user in hello expression'})
-        self.assertEqual(item.context_description(), u"username (Name of user in hello expression)")
+        self.assertIn(u"<b>{{ username }}</b>", item.context_description())
 
     def test_as_form_help_text(self):
         item = RegistrationItem('hello_template.html', help_text=u'Hello template',
@@ -50,6 +50,19 @@ class EmailTemplateRegistryTest(TestCase):
                                    help_context={'username': u'Name of user in hello expression'})
         help_context = template_registry.get_help_context('hello_template.html')
         self.assertIn('username', help_context)
+
+    def test_get_help_content(self):
+        template_registry = EmailTemplateRegistry()
+        template_registry.register('hello_template.html', help_text=u'Hello template',
+                                   help_context={
+                                       'username': (u'Name of user in hello expression', u'superman_90'),
+                                       'full_name': (u'Full user name', u'John Smith'),
+                                   })
+        help_content = template_registry.get_help_content('hello_template.html')
+        self.assertDictEqual(help_content, {
+            'username': u'superman_90',
+            'full_name': u'John Smith',
+        })
 
     def test_get_email_templates(self):
         template_registry = EmailTemplateRegistry()

--- a/emailtemplates/views.py
+++ b/emailtemplates/views.py
@@ -15,8 +15,7 @@ class EmailPreviewView(View):
         self.email_template = get_object_or_404(EmailTemplate, pk=self.kwargs['pk'])
 
     def get_context_data(self):
-        context = email_templates.get_help_content(self.email_template.title)
-        return context
+        return email_templates.get_help_content(self.email_template.title)
 
     def get(self, request, *args, **kwargs):
         self.get_email_template()

--- a/emailtemplates/views.py
+++ b/emailtemplates/views.py
@@ -12,14 +12,15 @@ from emailtemplates.registry import email_templates
 class EmailPreviewView(View):
 
     def get_email_template(self):
-        self.email_template = get_object_or_404(EmailTemplate, pk=self.kwargs['pk'])
+        return get_object_or_404(EmailTemplate, pk=self.kwargs['pk'])
 
     def get_context_data(self):
-        return email_templates.get_help_content(self.email_template.title)
+        email_template = self.get_email_template()
+        return email_templates.get_help_content(email_template.title)
 
     def get(self, request, *args, **kwargs):
-        self.get_email_template()
-        email_content = Template(self.email_template.content)
+        email_template = self.get_email_template()
+        email_content = Template(email_template.content)
         return HttpResponse(
             email_content.render(Context(self.get_context_data())),
             content_type='text/html; charset=utf-8'

--- a/emailtemplates/views.py
+++ b/emailtemplates/views.py
@@ -6,18 +6,21 @@ from django.template import Template, Context
 from django.views import View
 
 from emailtemplates.models import EmailTemplate
+from emailtemplates.registry import email_templates
 
 
 class EmailPreviewView(View):
+
     def get_email_template(self):
-        return get_object_or_404(EmailTemplate, pk=self.kwargs['pk'])
+        self.email_template = get_object_or_404(EmailTemplate, pk=self.kwargs['pk'])
 
     def get_context_data(self):
-        return {}
+        context = email_templates.get_help_content(self.email_template.title)
+        return context
 
     def get(self, request, *args, **kwargs):
-        email_template = self.get_email_template()
-        email_content = Template(email_template.content)
+        self.get_email_template()
+        email_content = Template(self.email_template.content)
         return HttpResponse(
             email_content.render(Context(self.get_context_data())),
             content_type='text/html; charset=utf-8'

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ tests_require = [
 
 setup(
     name='django-emailtemplates',
-    version='1.0.1',
+    version='1.0.2',
     packages=find_packages(),
     include_package_data=True,
     license='MIT License',


### PR DESCRIPTION
* `help_context` parameter may now be string (as before) or a tuple of two strings - then the second tuple element will become example value shown in email template preview. If not present, variable name will fill the context.